### PR TITLE
Integer value in converted hex value

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -4,6 +4,7 @@ const BigNumber = require("bignumber.js");
 const getHexValue = (value, pow = 18) => {
   let hexValue = BigNumber(value)
     .multipliedBy(BigNumber(10).pow(pow))
+    .integerValue()
     .toString(16);
   if (hexValue.length % 2 != 0) {
     hexValue = "0" + hexValue;


### PR DESCRIPTION
For tokens with few decimals (like USDC with only 6 decimals), operations can return more decimals and the converted hex value shows up with a point and a decimal part, resulting in an error when sending the transaction.
With this change only the integer part is taken after the multiply by the number of decimals, so no decimal part is used in the hex representation.